### PR TITLE
Upgrade gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.2.0
+  - 2.2.2
 deploy:
   provider: heroku
   api_key:
@@ -9,4 +9,4 @@ deploy:
   app: binaergewitter
   on:
     repo: Binaergewitter/serious-bg
-    rvm: 2.2.0
+    rvm: 2.2.2

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,6 @@ group :test do
   gem 'rack-test'
   gem 'test-unit'
   gem 'webmock'
-  gem 'feedvalidator', :require => 'feed_validator', :git => 'https://github.com/bandzoogle/feedvalidator.git'
+  gem 'feedvalidator' 
   gem 'typhoeus'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby "2.2.0"
+ruby "2.2.2"
 gem "rake"
 gem "serious", :path => './serious'
 gem "json"
@@ -13,6 +13,6 @@ group :test do
   gem 'rack-test'
   gem 'test-unit'
   gem 'webmock'
-  gem 'feedvalidator' 
+  gem 'feedvalidator'
   gem 'typhoeus'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
     rack-test (0.6.3)
       rack (>= 1.0)
     rake (10.4.2)
-    rb-fsevent (0.9.4)
+    rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     rdiscount (2.1.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-GIT
-  remote: https://github.com/bandzoogle/feedvalidator.git
-  revision: 13f7361b632a26df217a394b7832492a550969e9
-  specs:
-    feedvalidator (0.2.0)
-
 PATH
   remote: ./serious
   specs:
@@ -15,26 +9,27 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.7)
+    addressable (2.3.8)
     builder (3.2.2)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     coderay (1.1.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
-    ethon (0.7.2)
+    ethon (0.7.3)
       ffi (>= 1.3.0)
-    ffi (1.9.6)
+    feedvalidator (0.2.0)
+    ffi (1.9.8)
     hitimes (1.2.2)
     json (1.8.2)
-    listen (2.8.5)
-      celluloid (>= 0.15.2)
+    listen (2.10.0)
+      celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-    power_assert (0.2.2)
-    puma (2.11.1)
+    power_assert (0.2.3)
+    puma (2.11.3)
       rack (>= 1.1, < 2.0)
-    rack (1.6.0)
+    rack (1.6.1)
     rack-protection (1.5.3)
       rack
     rack-test (0.6.3)
@@ -47,21 +42,21 @@ GEM
     rerun (0.10.0)
       listen (~> 2.7, >= 2.7.3)
     safe_yaml (1.0.4)
-    sinatra (1.4.5)
+    sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
+      tilt (>= 1.3, < 3)
     stupid_formatter (0.2.0)
       coderay (>= 0.9.0)
       rdiscount (>= 1.5.0)
     test-unit (3.0.9)
       power_assert
-    tilt (1.4.1)
+    tilt (2.0.1)
     timers (4.0.1)
       hitimes
     typhoeus (0.7.1)
       ethon (>= 0.7.1)
-    webmock (1.20.4)
+    webmock (1.21.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
 
@@ -69,7 +64,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  feedvalidator!
+  feedvalidator
   json
   puma
   rack-test

--- a/tests/smoke_test.rb
+++ b/tests/smoke_test.rb
@@ -18,10 +18,13 @@ class SmokeTest < Test::Unit::TestCase
     get "/"
     assert last_response.ok?
   end
-  
+
   def test_feed_validates
     get "/podcast_feed/all/itunes/rss.xml"
+
+    WebMock.allow_net_connect!
     assert_valid_feed(last_response.body)
+    WebMock.disable_net_connect!
   end
 
   def test_mp3_feed_works
@@ -47,14 +50,14 @@ class SmokeTest < Test::Unit::TestCase
       last_id_set = current_id_set
     end
   end
-  
+
   def test_mp3_feed_has_a_next_link
     get "/podcast_feed/all/mp3/rss.xml?feed_size=2&page=2"
     assert last_response.ok?
     # There is a next link
     assert_include last_response.body, '/podcast_feed/all/mp3/rss.xml?feed_size=2&amp;page=3'
   end
-  
+
 
   def test_talk_category_feed_works
     get "/podcast_feed/talk/m4a/rss.xml"


### PR DESCRIPTION
- upgrade to ruby 2.2.2 https://devcenter.heroku.com/changelog-items/635
- upgrade gems
- use feedvalidator from ruby gems
- allow feedvalidator to use the network (which has the nice side effect that the feed is actually validated)