### PR TITLE
Add a podlove subscribe button to the abonnieren page

### DIFF
--- a/pages/abonnieren.markdown
+++ b/pages/abonnieren.markdown
@@ -9,6 +9,8 @@ Natürlich könnt ihr uns auch abonnieren. Wir sind schließlich ein Podcast. En
 
 Habt Spaß am Gerät.
 
+<script>window.podcastData={"title":"Binärgewitter","subtitle":"Now with more internet!","description":"Ein Podcast, der sich mit dem Web, Technologie und Open Source Software auseinander setzt.","cover":"","feeds":[{"type":"audio","format":"mp3","url":"http://blog.binaergewitter.de/podcast_feed/all/mp3/rss.xml"}]}</script><script class="podlove-subscribe-button" src="https://cdn.podlove.org/subscribe-button/javascripts/app.js" data-language="en" data-size="small" data-json-data="podcastData" data-color="#7bd164" data-format="rectangle" data-style="filled"></script><noscript><a href="http://blog.binaergewitter.de/podcast_feed/all/mp3/rss.xml">MP3 Feed</a></noscript>
+
 ## Feeds der Sendeformate
 
 <table class='table'>


### PR DESCRIPTION
Solves #203

![screen shot 2017-10-02 at 15 45 56](https://user-images.githubusercontent.com/29678/31083157-d3585f4c-a788-11e7-9744-45eb8dbe06a7.jpg)

Ich hatte zunächst einen subscribe Button für jeden Feed, aber:

* Die Ladezeit sorgt für eine unangenehme Animation
* Aufgrund von https://github.com/podlove/podlove-subscribe-button/blob/7e04ab5c2f45b34cdac170dac708e7d3dea7bfe8/README.md#override-button-color wird nur ein button gleichzeitig supported

Deshalb gibt es nur einen subscribe link, Pech gehabt.