### PR TITLE
switch back to download from cdn and latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
       - run: chmod +x stork-ubuntu-20-04
       - run: ./stork-ubuntu-20-04 --build stork.toml
       - name: Deploy to bgt server
+        if: github.ref == 'refs/heads/master'
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.DEPLOY_HOST }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,9 +20,9 @@ jobs:
         with:
           python-version: '3.x'
       - run: python gen-stork.py > stork.toml
-      - run: wget https://github.com/jameslittle230/stork/releases/download/v1.2.0/stork-ubuntu-latest
-      - run: chmod +x stork-ubuntu-latest
-      - run: ./stork-ubuntu-latest --build stork.toml
+      - run: wget https://files.stork-search.net/releases/latest/stork-ubuntu-20-04
+      - run: chmod +x stork-ubuntu-20-04
+      - run: ./stork-ubuntu-20-04 --build stork.toml
       - name: Deploy to bgt server
         uses: appleboy/scp-action@master
         with:


### PR DESCRIPTION
see https://github.com/jameslittle230/stork/discussions/180 for details
basically stork-ubuntu-latest is depricated
because there needs to be support for ubuntu 16.04 and 20.04 currently.