### PR TITLE
Feature/fix podcastlength

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.1
+FROM ruby:3.0.2
 ADD . /src
 WORKDIR /src
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,13 +16,13 @@ GEM
     coderay (1.1.3)
     crack (0.4.5)
       rexml
-    ethon (0.14.0)
+    ethon (0.15.0)
       ffi (>= 1.15.0)
-    excon (0.85.0)
+    excon (0.88.0)
     feedvalidator (0.2.2)
     ffi (1.15.4)
     hashdiff (1.0.1)
-    json (2.5.1)
+    json (2.6.1)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -31,7 +31,7 @@ GEM
     nio4r (2.5.8)
     power_assert (2.0.1)
     public_suffix (4.0.6)
-    puma (5.5.1)
+    puma (5.5.2)
       nio4r (~> 2.0)
     rack (2.2.3)
     rack-protection (2.1.0)
@@ -55,7 +55,7 @@ GEM
     stupid_formatter (0.2.0)
       coderay (>= 0.9.0)
       rdiscount (>= 1.5.0)
-    test-unit (3.4.7)
+    test-unit (3.5.1)
       power_assert
     tilt (2.0.10)
     typhoeus (1.4.0)
@@ -84,4 +84,4 @@ RUBY VERSION
    ruby 3.0.2p107
 
 BUNDLED WITH
-   2.2.28
+   2.2.31

--- a/serious/lib/serious.rb
+++ b/serious/lib/serious.rb
@@ -54,11 +54,36 @@ class Background
         end
       }
     rescue Exception => e
+      # return clean empty array
       chapters = Array.new
       puts e
     end
 
     chapters
+  end
+
+  def self.get_metadata(url)
+    metadata = nil
+    return metadata if url.nil?
+    begin
+      uri = URI.parse(url)
+      #create connection
+      Net::HTTP.start(uri.host, 80, {read_timeout: 5, open_timeout: 5}) {|http|
+        http.read_timeout = 5
+        http.open_timeout = 5
+        response = http.get(uri.path)
+
+        #get data
+        if response.kind_of? Net::HTTPSuccess
+          metadata = JSON.parse(response.body.force_encoding("UTF-8"))
+        end
+      }
+    rescue Exception => e
+      metadata = nil
+      puts e
+    end
+
+    metadata
   end
 end
 

--- a/serious/lib/serious/article.rb
+++ b/serious/lib/serious/article.rb
@@ -3,8 +3,6 @@
 # Backend for file-system based articles
 #
 
-require 'excon'
-
 class Serious::Article
   # Exception for invalid filenames
   class InvalidFilename < StandardError
@@ -67,7 +65,6 @@ class Serious::Article
     end
     
     private
-    
       # Returns all article files in articles path
       def article_paths
         @article_paths ||= Dir[File.join(Serious.articles, '*')].sort.reverse
@@ -97,32 +94,66 @@ class Serious::Article
     @audio ||= yaml["audioformats"] || {}
   end
 
+  # Hash for each file format the matching file size
   def audio_file_sizes
     return @audio_file_sizes if defined?(@audio_file_sizes)
+
     @audio_file_sizes = {}
-    $http_connections ||= {}
-    $file_sizes ||= {}
-    
-    threads = []
-    audioformats.each do |format, url|
-      uri = URI(url)
-      unless $http_connections.key?([uri.hostname, uri.port])
-        puts "Opening connection to server: #{uri.hostname}:#{uri.port}"
-        $http_connections[[uri.hostname, uri.port]] = Excon.new("#{uri.scheme}://#{uri.hostname}:#{uri.port}", :persistent => true) rescue nil
+    if not podcast_metadata.nil?
+      podcast_metadata["output_files"].each do |meta|
+        @audio_file_sizes[meta["ending"]] = meta["size"]
       end
-      conn = $http_connections[[uri.hostname, uri.port]]
-      if $file_sizes.key?(uri.to_s)
-        @audio_file_sizes[format] = $file_sizes[uri.to_s]
-      else
-        puts "Making head request for #{uri.to_s}"
-        threads << Thread.new do
-          @audio_file_sizes[format] = conn.request(:method => :head, :path => uri.path).headers['Content-Length'].to_i rescue 0
-          $file_sizes[uri.to_s] = @audio_file_sizes[format]
-        end
+    else
+      # fallback to 0 size
+      audioformats.each do |format, url|
+        @audio_file_sizes[format] = 0
       end
     end
-    threads.each{|t| t.join }
+
     @audio_file_sizes
+  end
+
+  # Duration as string formated as used by itunes:duration
+  def duration_timestring
+    return @duration_timestring if defined?(@duration_timestring)
+
+    if not podcast_metadata.nil?
+      @duration_timestring = podcast_metadata["length_timestring"]
+      # because feed duration does not support HH:MM:SS.000
+      # https://validator.w3.org/feed/docs/error/InvalidDuration.html
+      @duration_timestring = @duration_timestring.split(".")[0]
+    else
+      # fallback to 0 time
+      @duration_timestring = "00:00:00"
+    end
+
+    @duration_timestring
+  end
+
+  # Download and cache the json meta data produced by auphonic
+  # used for file size and length
+  def podcast_metadata
+    return @podcast_metadata if defined?(@podcast_metadata)
+
+    # NOTE(l33tname):
+    # this is a hack maybe we should configure the meta data file
+    # in the same way as we do the chaptermarks and then we could
+    # drop the audioformats
+    format_, url = audioformats.first
+    metadata_url = url.sub(".#{format_}", ".json")
+
+    $metadata_json_chache ||= {}
+    if $metadata_json_chache.key?(metadata_url)
+      @podcast_metadata = $metadata_json_chache[metadata_url]
+    else
+      @podcast_metadata = Background.get_metadata(metadata_url)
+      if not @podcast_metadata.nil?
+        @podcast_metadata.delete_if { |key, value| key.to_s.match(/(txt|json)/) }
+        $metadata_json_chache[metadata_url] = @podcast_metadata
+      end
+    end
+
+    @podcast_metadata
   end
 
   def chapters_url
@@ -156,8 +187,7 @@ class Serious::Article
     
     chapters
   end
-    
-  
+
   # Is the article published? by default it is
   def published?
     return @published if defined?(@published) && @published
@@ -168,7 +198,7 @@ class Serious::Article
     end
   end
 
-  # Lazy-loading audioformats accessor
+  # Lazy-loading categories accessor with fallback to empty array
   def categories
     @categories ||= yaml["categories"] || []
   end

--- a/serious/lib/serious/article.rb
+++ b/serious/lib/serious/article.rb
@@ -3,6 +3,8 @@
 # Backend for file-system based articles
 #
 
+require 'time'
+
 class Serious::Article
   # Exception for invalid filenames
   class InvalidFilename < StandardError
@@ -82,6 +84,11 @@ class Serious::Article
   # Lazy-loading title accessor
   def title
     @title ||= yaml["title"]
+  end
+
+  # Lazy-loading date_time accessor
+  def date_time
+    @date_time ||= Time.parse(yaml["date"])
   end
 
   # Lazy-loading release accessor

--- a/serious/lib/site/views/_podcast_controls.erb
+++ b/serious/lib/site/views/_podcast_controls.erb
@@ -10,7 +10,7 @@
             {
               link: `${location.protocol}//${location.host}<%= article.url %>`,
               title: '<%= article.title %>',
-              //duration: '02:23:47.468',
+              duration: '<%= article.duration_timestring %>',
               poster: '/img/binaergewitter_logo1x1.png',
               chapters: <%= article.chapter_json %>,
               audio: [

--- a/serious/lib/site/views/rss.builder
+++ b/serious/lib/site/views/rss.builder
@@ -10,8 +10,8 @@ xml.rss "xmlns:itunes" => "http://www.itunes.com/dtds/podcast-1.0.dtd", "xmlns:a
     xml.tag!("atom:link", :rel => 'next', :href => @next_url) if defined?(@next_url) && @next_url
     xml.description Serious.description
     xml.language 'de'
-    xml.pubDate @articles.first.date.rfc2822 unless @articles.empty?
-    xml.lastBuildDate @articles.first.date.rfc2822 unless @articles.empty?
+    xml.pubDate @articles.first.date_time.rfc2822 unless @articles.empty?
+    xml.lastBuildDate @articles.first.date_time.rfc2822 unless @articles.empty?
     xml.itunes :author, Serious.author
     xml.copyright "Creative Commons BY-SA 3.0 DE"
 
@@ -32,7 +32,7 @@ xml.rss "xmlns:itunes" => "http://www.itunes.com/dtds/podcast-1.0.dtd", "xmlns:a
       xml.item do
         xml.title article.title
         xml.description article.automatic_summary
-        xml.pubDate article.date.rfc2822
+        xml.pubDate article.date_time.rfc2822
         xml.itunes :author, Serious.author
         xml.itunes :summary, article.automatic_summary
         # In case we fudged the initial release, we can set the parameter

--- a/serious/lib/site/views/rss.builder
+++ b/serious/lib/site/views/rss.builder
@@ -51,11 +51,13 @@ xml.rss "xmlns:itunes" => "http://www.itunes.com/dtds/podcast-1.0.dtd", "xmlns:a
             selected_codec = @selected_audio_codec
           end
           url = article.audioformats[selected_codec]
-          type = "audio/x-#{selected_codec}"
+          type = "audio/#{selected_codec}"
           #According to the RSS Advisory Board's Best Practices Profile,
           #when an enclosure's size cannot be determined, a publisher should use a length of 0.
           xml.enclosure "url" => url, 'length' => article.audio_file_sizes[selected_codec].to_i.to_s, 'type' => type
         end
+
+        xml.itunes :duration, article.duration_timestring
 
         # chapter marks
         xml.tag!("psc:chapters", "xmlns:psc" => "http://podlove.org/simple-chapters", :version => "1.2") do

--- a/serious/lib/site/views/rss.builder
+++ b/serious/lib/site/views/rss.builder
@@ -31,6 +31,7 @@ xml.rss "xmlns:itunes" => "http://www.itunes.com/dtds/podcast-1.0.dtd", "xmlns:a
     @articles.each do |article|
       xml.item do
         xml.title article.title
+        xml.description article.automatic_summary
         xml.pubDate article.date.rfc2822
         xml.itunes :author, Serious.author
         xml.itunes :summary, article.automatic_summary


### PR DESCRIPTION
 fixing time duration in feed and web player

Parse the time duration and file size from auphonic meta data file.
This also reduces the requests since we don't need to
HEAD reqest the file size for each audio type.

und

 add decription in addition to itunes:summary 