### PR TITLE
update to new stork cli interface

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       - run: python gen-stork.py > stork.toml
       - run: wget https://files.stork-search.net/releases/latest/stork-ubuntu-20-04
       - run: chmod +x stork-ubuntu-20-04
-      - run: ./stork-ubuntu-20-04 --build stork.toml
+      - run: ./stork-ubuntu-20-04 build --input stork.toml --output bgt.st
       - name: Deploy to bgt server
         if: github.ref == 'refs/heads/master'
         uses: appleboy/scp-action@master

--- a/gen-stork.py
+++ b/gen-stork.py
@@ -31,8 +31,6 @@ files = [
 """)
 def footer():
     print("""]
-[output]
-filename = "bgt.st"
 """)
 
 def main():


### PR DESCRIPTION
Unfortunately i looked at our stork build:
```
Warning: The command line interface has been updated: please use `stork build` instead of `stork --build`. See `stork --help` for more.
Config Warnings:
The config option `output.filename` is deprecated and has no effect. Please use the --output command line option instead.
```