### PR TITLE
Update ruby and buildpack

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1.0
+          ruby-version: 3.1.2
           bundler-cache: true
       - run: bundle install
       - run: bundle exec rake TESTOPTS=-v

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby "3.1.0"
+ruby "3.1.2"
 
 gem "rake"
 gem "serious", :path => './serious'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -81,7 +82,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.1.0p0
+   ruby 3.1.2p20
 
 BUNDLED WITH
-   2.3.21
+   2.3.7

--- a/fly.toml
+++ b/fly.toml
@@ -6,7 +6,7 @@ kill_timeout = 5
 processes = []
 
 [build]
-  builder = "heroku/buildpacks:20"
+  builder = "heroku/buildpacks:22"
 
 [env]
   PORT = "8080"


### PR DESCRIPTION
Build pack 22 should have the right ruby version as far as I can see https://devcenter.heroku.com/articles/heroku-22-stack#available-software

I'll probably try to fiddle around with passenger instead of puma to see how memory usage is going, but let's try this first :)