### PR TITLE
Switch fly deployment to docker container with jemalloc ruby

### DIFF
--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -1,0 +1,14 @@
+ARG RUBY_VERSION=3.1.2-jemalloc
+FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-slim
+ADD . /src
+WORKDIR /src
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+RUN apt update; apt install -y libffi-dev gcc make automake autoconf libtool
+RUN bundle install --jobs=3 --retry=3 --deployment --path=vendor/bundle
+
+EXPOSE 8080
+
+CMD [ "bundle", "exec", "puma", "-e", "production", "-b", "tcp://0.0.0.0:8080", "-t", "0:5" ]

--- a/fly.toml
+++ b/fly.toml
@@ -6,7 +6,7 @@ kill_timeout = 5
 processes = []
 
 [build]
-  builder = "heroku/buildpacks:20"
+  dockerfile = "Dockerfile.fly"
 
 [env]
   PORT = "8080"

--- a/serious/serious.gemspec
+++ b/serious/serious.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rdoc"
   s.add_development_dependency 'simplecov'
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files         = Dir['**/*'].keep_if { |file| File.file?(file) }
+  s.test_files    = Dir['test/**/*']
+  s.executables   = []
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
We are running on the free tier of fly.io
Running on the free tier of something is VERY much our brand

Sadly, we're hitting the 256 MB limit and get OOM killed pretty often.

To solve this, I switched us from a heroku buildpack with some peasant ruby to a ruby that was compiled with jemalloc (from https://fullstaqruby.org/).

So far the result: About 50% memory reduction
<img width="586" alt="Screen Shot 2022-09-02 at 6 35 03 PM" src="https://user-images.githubusercontent.com/9519/188243024-2ea7b3e1-4776-4560-ac8a-5a6ec506750f.png">


I'm sure I'm doing something wrong with docker and should somehow clean up apt caches or something. But that's for the next PR.
