### PR TITLE
Blocklist prevention

### DIFF
--- a/serious/lib/site/views/_sidebar.erb
+++ b/serious/lib/site/views/_sidebar.erb
@@ -11,7 +11,7 @@
       <p>
         <strong>@binaergewitter</strong> auf
       </p>
-      <p class="social-icons">
+      <p class="free-social-icons">
         <a title="Twitter" href="https://twitter.com/binaergewitter">
           <i class="icon-twitter"></i>
         </a>

--- a/serious/lib/site/views/layout.erb
+++ b/serious/lib/site/views/layout.erb
@@ -77,7 +77,7 @@
       height: 100%;
     }
 
-    .social-icons a {
+    .free-social-icons a {
       font-size: 30px;
       text-decoration: none;
     }


### PR DESCRIPTION
Also, mir ist ende letzten Jahres aufgefallen, dass der Mastodon-link bei euch nicht angezeigt wurde.
Auf der Suche des Problems stellte sich die Class/ID "icon-mastodon" heraus, welche von der Filterliste Fanboy (easylist) pauschal geblockt wurde.
Gleichzeitig aber z.B. icon-facebook und ähnliches nicht geblockt wurde – das ging natürlich nicht.
Lange rede kurzer Sinn. Mastodon ist befreit. Eure Social-Icons wurden jetzt direkt geblockt:

https://github.com/easylist/easylist/commit/bfe4a04c19d917c42a60a07139718cf473c99d12


Mein Ansatz und Entschuldigung wäre jetzt, social-icons in free-social-icons umzubenennen um die Filterlisten zu umgehen. Wie ich finde ein sehr treffender Name. :D

MfG
Leo

P.S.
Das war wohl der Auslöser *hust
https://github.com/easylist/easylist/issues/14324