### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/articles/2017-09-24-binaergewitter-spezial-7-nixos.markdown
+++ b/articles/2017-09-24-binaergewitter-spezial-7-nixos.markdown
@@ -135,5 +135,5 @@ Endlich ist sie da. Die Spezial Sendung zu NixOS. Felix und Jörg sind NixOS Jü
   - `sudo install -d -m755 -o $USER -g $USER /nix`
   - `curl https://nixos.org/nix/install | sh`
 - ...oder per Paketmanager installieren ([AUR](https://aur.archlinux.org/packages/nix-multiuser/)):
-- [Auch ohne root nutzbar](https://nixos.wiki/wiki/Nix_Package_Manager#Install_Nix_without_root_permissions)
-- [Handbuch](https://nixos.org/nixos/manual/index.html), [Wiki](https://nixos.wiki), IRC: #nixos auf freenode, [Nix Pills](https://nixos.org/nixos/nix-pills/index.html)
+- [Auch ohne root nutzbar](https://wiki.nixos.org/wiki/Nix_Package_Manager#Install_Nix_without_root_permissions)
+- [Handbuch](https://nixos.org/nixos/manual/index.html), [Wiki](https://wiki.nixos.org), IRC: #nixos auf freenode, [Nix Pills](https://nixos.org/nixos/nix-pills/index.html)

--- a/articles/2023-06-14-binaergewitter-talk-number-316-klobi.markdown
+++ b/articles/2023-06-14-binaergewitter-talk-number-316-klobi.markdown
@@ -72,7 +72,7 @@ Es ist heiß draußen und wir hangeln uns mal wieder durch die heißesten Linux 
 - Easyroam / DFN - Zertifikate statt Username/Passwort
 - [How do I upgrade Nixos to use a new channel nixos version?]( https://unix.stackexchange.com/questions/491727/how-do-i-upgrade-nixos-to-use-a-new-channel-nixos-version )
   * `nix-collect-garbage -d`
-  * [Storage Optimizations]( https://nixos.wiki/wiki/Storage_optimization )
+  * [Storage Optimizations]( https://wiki.nixos.org/wiki/Storage_optimization )
 
 
 ## Lesefoo

--- a/articles/2024-01-24-binaergewitter-talk-number-330-opensourceplus.markdown
+++ b/articles/2024-01-24-binaergewitter-talk-number-330-opensourceplus.markdown
@@ -70,7 +70,7 @@ Wir sind wieder da mit einer neuen Ausgabe von Binärschneesturm Talk.
   * [liberapay]( https://en.liberapay.com/ )
 - Debian
   * flatbuffer & grpc
-  * [Nixos.wiki: Building RPM/DEB with nixpkgs]( https://nixos.wiki/wiki/Nixpkgs/Building_RPM_DEB_with_nixpkgs )
+  * [Nixos.wiki: Building RPM/DEB with nixpkgs]( https://wiki.nixos.org/wiki/Nixpkgs/Building_RPM_DEB_with_nixpkgs )
 
 ## Lesefoo
 - [Hans Reiser on ReiserFS deprecation]( https://lore.kernel.org/lkml/b98b29cf-27d9-49e0-b10b-1848399badfd@kittens.ph/T/#u )

--- a/articles/2024-04-20-binaergewitter-talk-335-kaputty.markdown
+++ b/articles/2024-04-20-binaergewitter-talk-335-kaputty.markdown
@@ -58,7 +58,7 @@ Wir sind zurück. Mit Disketten, Zügen und viel AI.
   - [xkcd: 2347]( https://xkcd.com/2347/ )
   - [Poettering: dlopen für systemd]( https://mastodon.social/@pid_eins/112256363180973672 )
 - [wiki.nixos.org](https://wiki.nixos.org)
-  * lassulus: sagt mal an, dass es ein neues offizielles nixos wiki gibt, die leute benutzen teilweise noch das alte
+  * lassulus: sagt mal an, dass es ein neues offizielles wiki.nixos.org gibt, die leute benutzen teilweise noch das alte
 - [NixCon CA Funding Drama]( https://nixos-users-against-mic-sponsorship.github.io/ )
   * [NixOS Foundation event sponsorship policy]( https://discourse.nixos.org/t/nixos-foundation-event-sponsorship-policy/43110 )
 - [AirBuds mit Wechselakku]( https://www.heise.de/news/Fairphone-Fairbuds-In-Ears-mit-Wechselakku-9678684.html )


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️