### PR TITLE
Update layout.erb grösser in breitem Fenster

### DIFF
--- a/serious/lib/site/views/layout.erb
+++ b/serious/lib/site/views/layout.erb
@@ -79,6 +79,25 @@
       font-size: 29px;
       text-decoration: none;
     }
+    /*-------------- grösser in breitem Fenster --------------*/
+    @media only screen and (min-width:1200px) {
+	    body, .form-control {
+		    font-size: 18px;
+	    }
+	    .container {
+		    width: 90%;
+		    max-width: 1360px;
+	    }
+    	h2, .h2 {
+    		font-size: 34px;
+    	}
+    	.panel-title {
+    		font-size: 22px;
+    	}
+    	blockquote {
+    		font-size: 20px;
+    	}
+    }
     /*-------------- Dark Mode --------------*/
     @media only screen and (prefers-color-scheme: dark) {
       /* Body und Panel links oben */


### PR DESCRIPTION
Auf dem grossen Monitor benutze ich den Browser-Zoom um entspannter zu lesen.

Hier ein Vorschlag für zusätzliches CSS, um bei Fensterbreite über 1200px die Schriftgrösse für den Fliesstext von 14px auf 18 px zu erhöhen. Die Texte im Podlove Player sind 16px gross, das passt immer noch.

Im Bildschirmfoto oben jetziges 14px, unten mit 18px, der Container darf dann auch etwas breiter werden:

![vorher-nachher](https://github.com/user-attachments/assets/94119b89-9a34-4f89-b32f-bb42845ed83c)
