### PR TITLE
Add jmalloc tuning to fly.io

### DIFF
--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -6,6 +6,7 @@ WORKDIR /src
 ENV LC_ALL=C.UTF-8
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8
+ENV MALLOC_CONF='dirty_decay_ms:1000,narenas:2,background_thread:true'
 RUN apt update && \
     apt install -y --no-install-recommends libffi-dev gcc make automake autoconf libtool && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Randomly grabbed the 'more heavily memory-optimized' version from https://gist.github.com/jjb/9ff0d3f622c8bbe904fe7a82e35152fc

We can always drop it if it doesn't do anything