### PR TITLE
GitHub-Ribbon: unten links auf kleinen Bildschirmen zeigen

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -287,12 +287,12 @@
 </head>
 
 <body>
-  <div class="github-fork-ribbon-wrapper left">
-    <div class="github-fork-ribbon green">
-      <a href="https://github.com/Binaergewitter/serious-bg" target="_blank" rel="noopener noreferrer">Fix me on
-        GitHub</a>
-    </div>
-  </div>
+  <a class="github-fork-ribbon left-top fixed ribbon-desktop-only" href="https://github.com/Binaergewitter/serious-bg"
+    target="_blank" rel="noopener noreferrer" data-ribbon="Fix me on GitHub" title="Fix me on GitHub">Fix me on
+    GitHub</a>
+  <a class="github-fork-ribbon left-bottom fixed ribbon-mobile-only" href="https://github.com/Binaergewitter/serious-bg"
+    target="_blank" rel="noopener noreferrer" data-ribbon="Fix me on GitHub" title="Fix me on GitHub">Fix me on
+    GitHub</a>
 
   {{ partial "navigation.html" . }}
 

--- a/static/css/github-ribbon.css
+++ b/static/css/github-ribbon.css
@@ -1,94 +1,138 @@
-/* GitHub Ribbon CSS - Fork me on GitHub */
-/* Based on https://github.blog/news-insights/the-library/github-ribbons/ */
-
-.github-fork-ribbon-wrapper {
-    width: 100px;
-    height: 100px;
-    position: fixed;
-    overflow: hidden;
-    top: 0;
-    z-index: 9999;
-    pointer-events: none;
-}
-
-.github-fork-ribbon-wrapper.right {
-    right: 0;
-}
-
-.github-fork-ribbon-wrapper.left {
-    left: 0;
-}
+/*!
+ * "Fork me on GitHub" CSS ribbon, vendored from
+ * https://github.com/simonwhitaker/github-fork-ribbon-css (v0.2.3, MIT License)
+ * with site-specific tweaks: green background colour, and swapping to the
+ * bottom-left corner (instead of shrinking/repositioning the top-left one)
+ * on small screens so it never overlaps the mobile nav/title.
+ */
 
 .github-fork-ribbon {
+    width: 12.1em;
+    height: 12.1em;
     position: absolute;
-    padding: 1px 0;
-    background-color: #333;
-    background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
-    box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.5);
-    pointer-events: auto;
-    font: 700 11px "Helvetica Neue", Helvetica, Arial, sans-serif;
+    overflow: hidden;
+    top: 0;
+    right: 0;
     z-index: 9999;
-    pointer-events: auto;
-}
-
-.github-fork-ribbon a,
-.github-fork-ribbon a:hover {
-    color: #fff;
+    pointer-events: none;
+    font-size: 13px;
     text-decoration: none;
-    text-shadow: 0 -1px rgba(0, 0, 0, 0.5);
-    text-align: center;
-    width: 140px;
-    line-height: 16px;
-    display: inline-block;
-    padding: 1px 0;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    text-indent: -999999px;
 }
 
-.github-fork-ribbon-wrapper.right .github-fork-ribbon {
-    top: 28px;
-    right: -30px;
+.github-fork-ribbon.fixed {
+    position: fixed;
+}
+
+.github-fork-ribbon:hover,
+.github-fork-ribbon:active {
+    background-color: rgba(0, 0, 0, 0.0);
+}
+
+.github-fork-ribbon:before,
+.github-fork-ribbon:after {
+    /* The right and left classes determine the side we attach our banner to */
+    position: absolute;
+    display: block;
+    width: 15.38em;
+    height: 1.54em;
+
+    top: 3.23em;
+    right: -3.23em;
+
+    box-sizing: content-box;
     transform: rotate(45deg);
 }
 
-.github-fork-ribbon-wrapper.left .github-fork-ribbon {
-    top: 28px;
-    left: -30px;
+.github-fork-ribbon:before {
+    content: "";
+
+    /* Add a bit of padding to give some substance outside the "stitching" */
+    padding: .38em 0;
+
+    /* Set the base colour */
+    background-color: #090;
+
+    /* Gradient: transparent black at the top to almost-transparent black at the bottom */
+    background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+
+    /* Add a drop shadow */
+    box-shadow: 0 .15em .23em 0 rgba(0, 0, 0, 0.5);
+
+    pointer-events: auto;
+}
+
+.github-fork-ribbon:after {
+    /* Set the text from the data-ribbon attribute */
+    content: attr(data-ribbon);
+
+    /* Set the text properties */
+    color: #fff;
+    font: 700 1em "Helvetica Neue", Helvetica, Arial, sans-serif;
+    line-height: 1.54em;
+    text-decoration: none;
+    text-shadow: 0 -.08em rgba(0, 0, 0, 0.5);
+    text-align: center;
+    text-indent: 0;
+
+    /* Set the layout properties */
+    padding: .15em 0;
+    margin: .15em 0;
+
+    /* Add "stitching" effect */
+    border-width: .08em 0;
+    border-style: dotted;
+    border-color: rgba(255, 255, 255, 0.7);
+}
+
+.github-fork-ribbon.left-top,
+.github-fork-ribbon.left-bottom {
+    right: auto;
+    left: 0;
+}
+
+.github-fork-ribbon.left-bottom,
+.github-fork-ribbon.right-bottom {
+    top: auto;
+    bottom: 0;
+}
+
+.github-fork-ribbon.left-top:before,
+.github-fork-ribbon.left-top:after,
+.github-fork-ribbon.left-bottom:before,
+.github-fork-ribbon.left-bottom:after {
+    right: auto;
+    left: -3.23em;
+}
+
+.github-fork-ribbon.left-bottom:before,
+.github-fork-ribbon.left-bottom:after,
+.github-fork-ribbon.right-bottom:before,
+.github-fork-ribbon.right-bottom:after {
+    top: auto;
+    bottom: 3.23em;
+}
+
+.github-fork-ribbon.left-top:before,
+.github-fork-ribbon.left-top:after,
+.github-fork-ribbon.right-bottom:before,
+.github-fork-ribbon.right-bottom:after {
     transform: rotate(-45deg);
 }
 
-/* Color variations */
-.github-fork-ribbon.red {
-    background-color: #a00;
+/* Site-specific: show the top-left ribbon on regular screens, and swap to
+   the bottom-left one (out of the way of the nav/title) on small screens. */
+.ribbon-mobile-only {
+    display: none;
 }
 
-.github-fork-ribbon.green {
-    background-color: #090;
-}
-
-.github-fork-ribbon.black {
-    background-color: #333;
-}
-
-.github-fork-ribbon.orange {
-    background-color: #f80;
-}
-
-.github-fork-ribbon.gray {
-    background-color: #888;
-}
-
-.github-fork-ribbon.white {
-    background-color: #fff;
-}
-
-.github-fork-ribbon.white a {
-    color: #000;
-    text-shadow: 0 1px rgba(255, 255, 255, 0.5);
-}
-
-/* Responsive - hide on small screens */
 @media screen and (max-width: 768px) {
-    .github-fork-ribbon-wrapper {
+    .ribbon-desktop-only {
         display: none;
+    }
+
+    .ribbon-mobile-only {
+        display: block;
+        font-size: 10px;
     }
 }


### PR DESCRIPTION
Der Ribbon war unter 768px Breite bisher komplett per display:none versteckt. Ersetzt das selbstgebaute Ribbon-CSS durch die echte simonwhitaker/github-fork-ribbon-css (v0.2.3, MIT), lokal eingebunden. Es gibt jetzt zwei Ribbon-Elemente: das gewohnte oben links für normale Bildschirmbreiten, und eines unten links (komplett aus dem Weg von Navigation/Titel) für mobile Ansichten - per CSS unterhalb von 768px eingeblendet statt des oberen. Beide bleiben position:fixed wie zuvor auf dem Desktop; die Größe skaliert über die em-basierten Maßeinheiten der Bibliothek, auf Mobilgeräten leicht verkleinert.

Damit entfallen die vorherigen Verrenkungen (Schrumpfen/Verschieben des oben-links-Ribbons, Padding am Titel), da mobil jetzt eine andere Ecke genutzt wird.