### PR TITLE
Fix/teaser list indent

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -28,8 +28,8 @@
 </section>
 {{ end }}
 
-{{ range first $recentCount $pages }}
-{{ partial "article_summary.html" . }}
+{{ range $i, $p := first $recentCount $pages }}
+{{ partial "article_summary.html" (dict "Page" $p "IsFirst" (eq $i 0)) }}
 {{ end }}
 
 {{ $archived := after $recentCount $pages | first $archiveCount }}

--- a/layouts/partials/article_summary.html
+++ b/layouts/partials/article_summary.html
@@ -16,17 +16,27 @@
 
         {{ $shownSafeSection := false }}
         {{ if $isFirst }}
-        {{/* Grab just the first shownotes section (heading + its list) for the
-             newest post, cutting the string right before the *next* <h2>
-             instead of at a word count. Since that's a boundary between two
-             complete top-level elements, everything before the cut is
-             guaranteed to already be balanced/closed - unlike Hugo's
-             built-in word-count .Summary, which can (and does) truncate
-             mid-list and leave a dangling <ul>/<li> that swallows whatever
-             HTML comes after it (see gohugoio/hugo#7372, #8910, #7926). */}}
+        {{/* Append a handful of shownotes sections (heading + list each) for
+             the newest post, cutting the string right before the next
+             <h2> instead of at a word count. Since that's a boundary
+             between two complete top-level elements, everything before the
+             cut is guaranteed to already be balanced/closed - unlike
+             Hugo's built-in word-count .Summary, which can (and does)
+             truncate mid-list and leave a dangling <ul>/<li> that
+             swallows whatever HTML comes after it (see gohugoio/hugo
+             #7372, #8910, #7926). Keep adding whole sections until we
+             pass a rough character budget, so shorter episodes still get
+             a few sections and longer ones don't balloon forever. */}}
         {{ $sections := split $page.Content "<h2" }}
-        {{ if gt (len $sections) 1 }}
-        {{ printf "<h2%s" (index $sections 1) | replaceRE "</h1>" "</h2>" | safeHTML }}
+        {{ $maxChars := 1500 }}
+        {{ $extra := "" }}
+        {{ range $idx, $sec := $sections }}
+        {{ if and (gt $idx 0) (or (eq $idx 1) (lt (len $extra) $maxChars)) }}
+        {{ $extra = printf "%s<h2%s" $extra $sec }}
+        {{ end }}
+        {{ end }}
+        {{ if $extra }}
+        {{ $extra | replaceRE "</h1>" "</h2>" | safeHTML }}
         {{ $shownSafeSection = true }}
         {{ end }}
         {{ end }}

--- a/layouts/partials/article_summary.html
+++ b/layouts/partials/article_summary.html
@@ -1,24 +1,44 @@
+{{ $page := .Page }}
+{{ $isFirst := .IsFirst }}
+
 <article class="post">
     <header>
         <h2>
-            <a href="{{ .Permalink }}">{{ .Title }}</a>
-            <small class="date">{{ .Date.Format .Site.Params.date_format }}</small>
+            <a href="{{ $page.Permalink }}">{{ $page.Title }}</a>
+            <small class="date">{{ $page.Date.Format $page.Site.Params.date_format }}</small>
         </h2>
     </header>
 
     <div class="content">
-        {{ with .Description }}
+        {{ with $page.Description }}
         <p>{{ . }}</p>
-        {{ else }}
-        {{ .Summary | replaceRE "<h1" "<h2" | replaceRE "</h1>" "</h2>" | safeHTML }}
         {{ end }}
 
-        {{ if or .Description .Truncated }}
-        <p><a href="{{ .Permalink }}">Weiterlesen...</a></p>
+        {{ $shownSafeSection := false }}
+        {{ if $isFirst }}
+        {{/* Grab just the first shownotes section (heading + its list) for the
+             newest post, cutting the string right before the *next* <h2>
+             instead of at a word count. Since that's a boundary between two
+             complete top-level elements, everything before the cut is
+             guaranteed to already be balanced/closed - unlike Hugo's
+             built-in word-count .Summary, which can (and does) truncate
+             mid-list and leave a dangling <ul>/<li> that swallows whatever
+             HTML comes after it (see gohugoio/hugo#7372, #8910, #7926). */}}
+        {{ $sections := split $page.Content "<h2" }}
+        {{ if gt (len $sections) 1 }}
+        {{ printf "<h2%s" (index $sections 1) | replaceRE "</h1>" "</h2>" | safeHTML }}
+        {{ $shownSafeSection = true }}
+        {{ end }}
         {{ end }}
 
-        {{ if .Params.audioformats }}
-        {{ partial "podcast_controls.html" . }}
+        {{ if not (or $page.Description $shownSafeSection) }}
+        {{ $page.Summary | replaceRE "<h1" "<h2" | replaceRE "</h1>" "</h2>" | safeHTML }}
+        {{ end }}
+
+        <p><a href="{{ $page.Permalink }}">Weiterlesen...</a></p>
+
+        {{ if $page.Params.audioformats }}
+        {{ partial "podcast_controls.html" $page }}
         {{ end }}
     </div>
 </article>

--- a/layouts/partials/article_summary.html
+++ b/layouts/partials/article_summary.html
@@ -7,9 +7,13 @@
     </header>
 
     <div class="content">
+        {{ with .Description }}
+        <p>{{ . }}</p>
+        {{ else }}
         {{ .Summary | replaceRE "<h1" "<h2" | replaceRE "</h1>" "</h2>" | safeHTML }}
+        {{ end }}
 
-        {{ if .Truncated }}
+        {{ if or .Description .Truncated }}
         <p><a href="{{ .Permalink }}">Weiterlesen...</a></p>
         {{ end }}
 


### PR DESCRIPTION
# Problem
Der Teaser-Text jeder Folge auf der Startseite wurde über Hugos automatische .Summary-Kürzung erzeugt. Diese schneidet nach fester Wortanzahl – auch mitten in einer Markdown-Liste – und lässt dabei manchmal ein offenes ```<ul>/<li>``` zurück. Der Browser hängt dann den „Weiterlesen…"-Link und den Podcast-Player fälschlich als Kind dieses Listenpunkts ein und sie erben dessen Einrückung. Sichtbar z. B. bei Folge 384 unter „AI der Woche". Bekanntes, seit Jahren offenes Hugo-Problem: gohugoio/hugo#7372, #8910, #7926.

# Lösung

Teaser nutzt jetzt bevorzugt das von Hand geschriebene description-Frontmatter-Feld (reiner Text, keine Listen, bisher nur für Meta-Tags genutzt) statt .Summary.
Ältere Artikel ohne description fallen weiterhin auf .Summary zurück (unverändertes Verhalten, keine Regression).
Für die neueste Folge wird zusätzlich mehr Kontext gezeigt: ganze Shownotes-Abschnitte (Überschrift + Liste) werden angehängt, bis ein Zeichen-Budget (1500) überschritten ist. Der Schnitt erfolgt strukturell direkt vor der nächsten ```<h2>```-Überschrift statt nach Wortanzahl – exakt an der Grenze zwischen zwei vollständigen Elementen –, wodurch das Ergebnis immer korrekt geschlossenes HTML ist.