### PR TITLE
Mobiles GitHub-Ribbon: -webkit-transform wieder ergänzen (iOS-Fix)

### DIFF
--- a/static/css/github-ribbon.css
+++ b/static/css/github-ribbon.css
@@ -41,6 +41,13 @@
     right: -3.23em;
 
     box-sizing: content-box;
+
+    /* iOS Safari (older WebKit) ignores the unprefixed transform on these
+       pseudo-elements and renders them un-rotated as a thin horizontal bar,
+       so keep the -webkit- prefix the upstream library shipped. */
+    -webkit-transform: rotate(45deg);
+    -moz-transform: rotate(45deg);
+    -ms-transform: rotate(45deg);
     transform: rotate(45deg);
 }
 
@@ -117,6 +124,9 @@
 .github-fork-ribbon.left-top:after,
 .github-fork-ribbon.right-bottom:before,
 .github-fork-ribbon.right-bottom:after {
+    -webkit-transform: rotate(-45deg);
+    -moz-transform: rotate(-45deg);
+    -ms-transform: rotate(-45deg);
     transform: rotate(-45deg);
 }
 


### PR DESCRIPTION
Auf echtem iOS-Safari erschien das mobile Ribbon (unten links) nur als duenner horizontaler Balken statt als diagonales Eck-Banner. Ursache: die Vendor-Praefixe waren beim Uebernehmen der Bibliothek entfernt worden, und aeltere WebKit-Versionen ignorieren das praefixlose `transform` auf den :before/:after-Pseudoelementen. Ohne Rotation kollabieren diese auf ihre natuerliche 153x15px-Form -> der beobachtete Balken.

Praefixe (-webkit-/-moz-/-ms-) wie in der Ursprungsbibliothek wieder hergestellt. Verifiziert unter Playwright/WebKit mit iPhone-14-Emulation (mobil unten links + Desktop oben links rendern korrekt).