### PR TITLE
Podcast-Metadaten für Maschinen/Agents besser zugänglich machen

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -19,6 +19,7 @@
   <link rel="alternate" type="application/rss+xml" title="{{ .Site.Title }} Podcast MP3 Feed" href="{{ "podcast_feed/all/mp3/rss.xml" | absURL }}" />
   <link rel="alternate" type="application/rss+xml" title="{{ .Site.Title }} Podcast Opus Feed" href="{{ "podcast_feed/all/opus/rss.xml" | absURL }}" />
   <link rel="alternate" type="application/rss+xml" title="{{ .Site.Title }} Website RSS" href="{{ "rss.xml" | absURL }}" />
+  <link rel="alternate" type="application/json" title="{{ .Site.Title }} Suchindex (JSON)" href="{{ "index.json" | absURL }}" />
 
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/layouts/_default/list.rss.xml
+++ b/layouts/_default/list.rss.xml
@@ -76,6 +76,7 @@
         {{ $mimeType := cond (eq $firstFormat "mp3") "audio/mpeg" (printf "audio/%s" $firstFormat) }}
         <enclosure url="{{ $url }}" length="{{ printf "%.0f" $size }}" type="{{ $mimeType }}" />
         <itunes:duration>{{ $duration }}</itunes:duration>
+        {{ with .Params.transcript }}<podcast:transcript url="{{ . }}" type="application/json" />{{ end }}
 
         {{ $chaptersUrl := .Params.chapters | default (replace $url (printf ".%s" $firstFormat) ".chapters.txt") }}
         {{ $chaptersRaw := "" }}

--- a/layouts/_default/podcast_feed.rss.xml
+++ b/layouts/_default/podcast_feed.rss.xml
@@ -94,6 +94,7 @@
             {{ $mimeType := cond (eq $targetCodec "mp3") "audio/mpeg" (printf "audio/%s" $targetCodec) }}
             <enclosure url="{{ $url }}" length="{{ printf "%.0f" $size }}" type="{{ $mimeType }}" />
             <itunes:duration>{{ $duration }}</itunes:duration>
+            {{ with .Params.transcript }}<podcast:transcript url="{{ . }}" type="application/json" />{{ end }}
 
             {{ $chaptersUrl := .Params.chapters }}
             {{ if not $chaptersUrl }}

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -76,6 +76,7 @@
         {{ $mimeType := cond (eq $firstFormat "mp3") "audio/mpeg" (printf "audio/%s" $firstFormat) }}
         <enclosure url="{{ $url }}" length="{{ printf "%.0f" $size }}" type="{{ $mimeType }}" />
         <itunes:duration>{{ $duration }}</itunes:duration>
+        {{ with .Params.transcript }}<podcast:transcript url="{{ . }}" type="application/json" />{{ end }}
 
         {{ $chaptersUrl := .Params.chapters | default (replace $url (printf ".%s" $firstFormat) ".chapters.txt") }}
         {{ $chaptersRaw := "" }}

--- a/layouts/index.json
+++ b/layouts/index.json
@@ -1,7 +1,25 @@
 {{- $searchIndex := slice -}}
 {{- range .Site.AllPages -}}
   {{- if and .Title .Permalink (or (eq .Section "post") (eq .Section "pages")) -}}
-    {{- $entry := dict "title" .Title "permalink" (.Permalink | absURL) "summary" (.Summary | plainify) "content" .Plain -}}
+    {{- $entry := dict
+        "title" .Title
+        "permalink" (.Permalink | absURL)
+        "summary" (.Summary | plainify)
+        "content" .Plain -}}
+    {{- if eq .Section "post" -}}
+      {{- /* Episode metadata from front matter only (no remote fetches, so the
+             full-archive build stays fast). Richer per-episode data (duration,
+             parsed chapters) lives in the RSS feeds and on the episode page. */ -}}
+      {{- $episodeNumber := "" -}}
+      {{- with findRE `#(\d+)` .Title 1 -}}{{- $episodeNumber = replace (index . 0) "#" "" -}}{{- end -}}
+      {{- $entry = merge $entry (dict
+          "date" (.Date.Format "2006-01-02T15:04:05Z07:00")
+          "categories" (.Params.categories | default "")
+          "episodeNumber" $episodeNumber
+          "audioformats" (.Params.audioformats | default dict)
+          "chapters" (.Params.chapters | default "")
+          "transcript" (.Params.transcript | default "")) -}}
+    {{- end -}}
     {{- $searchIndex = $searchIndex | append $entry -}}
   {{- end -}}
 {{- end -}}

--- a/layouts/partials/episode_extras.html
+++ b/layouts/partials/episode_extras.html
@@ -1,0 +1,23 @@
+{{- /* Server-rendered chapter list and transcript link for an episode, so the
+       episode structure and the pointer to the transcript are present in the
+       HTML itself (readable by agents/crawlers without running the player JS). */ -}}
+{{- $meta := partial "episode_meta.html" (dict "page" .) -}}
+{{- if or $meta.chapters $meta.transcript -}}
+<section class="episode-meta">
+  {{- with $meta.chapters }}
+  <details class="episode-chapters" open>
+    <summary><h2>Kapitel</h2></summary>
+    <ol class="chapters">
+      {{- range . }}
+      <li><span class="chapter-start">{{ .startHms }}</span> <span class="chapter-title">{{ .title }}</span></li>
+      {{- end }}
+    </ol>
+  </details>
+  {{- end }}
+  {{- with $meta.transcript }}
+  <p class="episode-transcript">
+    <a href="{{ . }}" rel="alternate" type="application/json">Transkript (JSON)</a>
+  </p>
+  {{- end }}
+</section>
+{{- end -}}

--- a/layouts/partials/episode_meta.html
+++ b/layouts/partials/episode_meta.html
@@ -1,0 +1,93 @@
+{{- /*
+  Returns a dict of machine-readable metadata derived for a single episode, so
+  the JSON-LD (schema.html) and the on-page rendering (single.html) stay in
+  sync without each re-implementing the parsing. Fetched remote resources are
+  cached by Hugo per build URL, so calling this alongside podcast_controls.html
+  on the same page does not double the network cost.
+
+  Returns:
+    audioformats    map  front-matter audioformats (may be nil)
+    transcript      str  transcript URL ("" if none)
+    chapters        []   slice of { start, startHms, title }
+    durationSeconds  int  total length in seconds (0 if unknown)
+    durationIso     str  ISO-8601 duration, e.g. "PT2H23M13S" ("" if unknown)
+    episodeNumber   str  parsed from a "#123" in the title ("" if none)
+*/ -}}
+{{- $page := .page -}}
+{{- $audio := $page.Params.audioformats -}}
+{{- $transcript := $page.Params.transcript | default "" -}}
+{{- $chapters := slice -}}
+{{- $durationSeconds := 0 -}}
+{{- $durationIso := "" -}}
+{{- $episodeNumber := "" -}}
+
+{{- /* Episode number from the title, e.g. "Binärgewitter Talk #384: …" -> 384 */ -}}
+{{- $m := findRE `#(\d+)` $page.Title 1 -}}
+{{- with $m -}}
+  {{- $episodeNumber = replace (index . 0) "#" "" -}}
+{{- end -}}
+
+{{- if $audio -}}
+  {{- $firstFormat := "" -}}
+  {{- $firstUrl := "" -}}
+  {{- range $k, $v := $audio -}}
+    {{- if eq $firstFormat "" -}}{{- $firstFormat = $k -}}{{- $firstUrl = $v -}}{{- end -}}
+  {{- end -}}
+
+  {{- /* Metadata JSON sits next to the audio (…mp3 -> …json) and carries length. */ -}}
+  {{- $metaUrl := $firstUrl -}}
+  {{- range slice "mp3" "ogg" "opus" "m4a" -}}
+    {{- $metaUrl = replace $metaUrl (printf ".%s" .) ".json" -}}
+  {{- end -}}
+  {{- if hasPrefix $metaUrl "http" -}}
+    {{- with resources.GetRemote $metaUrl -}}
+      {{- with .Content -}}
+        {{- $meta := . | transform.Unmarshal -}}
+        {{- if and (reflect.IsMap $meta) $meta.length -}}
+          {{- $durationSeconds = int (math.Floor $meta.length) -}}
+          {{- $h := int (math.Floor (div $durationSeconds 3600)) -}}
+          {{- $mm := int (math.Floor (div (math.Mod $durationSeconds 3600) 60)) -}}
+          {{- $ss := int (math.Mod $durationSeconds 60) -}}
+          {{- $durationIso = printf "PT%dH%dM%dS" $h $mm $ss -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- /* Chapters live in a sidecar …chapters.txt ("HH:MM:SS.mmm Title" lines). */ -}}
+  {{- $chaptersUrl := $page.Params.chapters -}}
+  {{- if not $chaptersUrl -}}
+    {{- $chaptersUrl = $firstUrl -}}
+    {{- range slice "mp3" "ogg" "opus" "m4a" -}}
+      {{- $chaptersUrl = replace $chaptersUrl (printf ".%s" .) ".chapters.txt" -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if hasPrefix $chaptersUrl "http" -}}
+    {{- with resources.GetRemote $chaptersUrl -}}
+      {{- with .Content -}}
+        {{- range (split . "\n") -}}
+          {{- $line := trim . " \r" -}}
+          {{- if $line -}}
+            {{- $parts := split $line " " -}}
+            {{- if ge (len $parts) 2 -}}
+              {{- $start := index $parts 0 -}}
+              {{- $title := delimit (after 1 $parts) " " -}}
+              {{- $chapters = $chapters | append (dict
+                    "start" $start
+                    "startHms" (index (split $start ".") 0)
+                    "title" $title) -}}
+            {{- end -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return (dict
+      "audioformats" $audio
+      "transcript" $transcript
+      "chapters" $chapters
+      "durationSeconds" $durationSeconds
+      "durationIso" $durationIso
+      "episodeNumber" $episodeNumber) -}}

--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -10,9 +10,25 @@
   "inLanguage" "de-DE"
 -}}
 {{- if $page.IsHome -}}
+{{- /* WebSite with a SearchAction advertises the /index.json search endpoint so
+       agents (and search engines) know how to query the archive directly. */ -}}
+{{- $website := dict
+  "@context" "https://schema.org"
+  "@type" "WebSite"
+  "name" $page.Site.Title
+  "url" $page.Site.BaseURL
+  "inLanguage" "de-DE"
+  "publisher" (dict "@type" "Organization" "name" $page.Site.Params.author "url" $page.Site.BaseURL "logo" $image)
+  "potentialAction" (dict
+    "@type" "SearchAction"
+    "target" (dict "@type" "EntryPoint" "urlTemplate" (printf "%s?q={search_term_string}" $page.Site.BaseURL))
+    "query-input" "required name=search_term_string")
+-}}
 {{- $schema := merge $series (dict "@context" "https://schema.org") -}}
+<script type="application/ld+json">{{ $website | jsonify | safeJS }}</script>
 <script type="application/ld+json">{{ $schema | jsonify | safeJS }}</script>
 {{- else if eq $page.Section "post" -}}
+{{- $meta := partial "episode_meta.html" (dict "page" $page) -}}
 {{- $episode := dict
   "@context" "https://schema.org"
   "@type" "PodcastEpisode"
@@ -22,12 +38,40 @@
   "datePublished" ($page.Date.Format "2006-01-02T15:04:05Z07:00")
   "dateModified" ($page.Lastmod.Format "2006-01-02T15:04:05Z07:00")
   "image" $image
+  "inLanguage" "de-DE"
   "partOfSeries" $series
 -}}
-{{- with $page.Params.audioformats -}}
-  {{- with (index . "mp3") -}}
-    {{- $episode = merge $episode (dict "associatedMedia" (dict "@type" "MediaObject" "contentUrl" . "encodingFormat" "audio/mpeg")) -}}
+{{- with $meta.episodeNumber -}}
+  {{- $episode = merge $episode (dict "episodeNumber" .) -}}
+{{- end -}}
+{{- with $meta.durationIso -}}
+  {{- $episode = merge $episode (dict "duration" .) -}}
+{{- end -}}
+{{- /* Every offered audio format as its own MediaObject. */ -}}
+{{- with $meta.audioformats -}}
+  {{- $mediaMime := dict "mp3" "audio/mpeg" "ogg" "audio/ogg" "opus" "audio/opus" "m4a" "audio/mp4" -}}
+  {{- $media := slice -}}
+  {{- range $fmt, $url := . -}}
+    {{- $media = $media | append (dict
+        "@type" "MediaObject"
+        "contentUrl" $url
+        "encodingFormat" (index $mediaMime $fmt | default (printf "audio/%s" $fmt))) -}}
   {{- end -}}
+  {{- with $media -}}{{- $episode = merge $episode (dict "associatedMedia" .) -}}{{- end -}}
+{{- end -}}
+{{- /* Contributors (the ones actually on this episode) as Person entities. */ -}}
+{{- $people := slice -}}
+{{- range $voice, $val := $page.Params.voices -}}
+  {{- if $val -}}
+    {{- with (index $page.Site.Params.contributors $voice) -}}
+      {{- $people = $people | append (dict "@type" "Person" "name" .name) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- with $people -}}{{- $episode = merge $episode (dict "actor" .) -}}{{- end -}}
+{{- /* Transcript as a linked resource (not inline text). */ -}}
+{{- with $meta.transcript -}}
+  {{- $episode = merge $episode (dict "transcript" (dict "@type" "MediaObject" "contentUrl" . "encodingFormat" "application/json")) -}}
 {{- end -}}
 <script type="application/ld+json">{{ $episode | jsonify | safeJS }}</script>
 {{- end -}}

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -3,7 +3,7 @@
     <header>
         <h1>
             <a href="{{ .Permalink }}">{{ .Title }}</a>
-            <small class="date">{{ .Date.Format .Site.Params.date_format }}</small>
+            <small class="date"><time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format .Site.Params.date_format }}</time></small>
         </h1>
     </header>
 
@@ -12,6 +12,7 @@
 
         {{ if .Params.audioformats }}
         {{ partial "podcast_controls.html" . }}
+        {{ partial "episode_extras.html" . }}
         {{ end }}
     </div>
 


### PR DESCRIPTION
## Ziel

Rich data, die pro Episode schon existiert, aber bisher nur **clientseitig** (Player-JS) oder im Front Matter steckte, jetzt **serverseitig** als HTML / JSON-LD / Feed-Tags ausgeben – damit Agents und Crawler sie ohne JS-Ausführung lesen können. Kein `llms.txt`-Spekulatius, sondern vorhandene Daten sichtbar machen.

## Änderungen

- **Neues Partial `episode_meta.html`** – leitet Kapitel, Dauer, Transkript-URL, Audioformate und Episodennummer einheitlich ab (Remote-Fetches cached Hugo pro Build, kein doppelter Traffic neben dem Player).
- **JSON-LD (`schema.html`)** – `PodcastEpisode` um `duration`, `episodeNumber`, `inLanguage`, **alle** Audioformate, Mitwirkende (`actor`/`Person`) und verlinktes Transkript erweitert. Startseite bekommt zusätzl