### PR TITLE
CI: Mobile-Screenshot nicht mehr als riesigen Vollseiten-Streifen zeigen

### DIFF
--- a/.github/scripts/screenshot.js
+++ b/.github/scripts/screenshot.js
@@ -5,7 +5,11 @@ const { chromium } = require('playwright');
 const URL = 'http://localhost:8080/';
 const OUT = 'screenshots';
 
-async function shoot(browser, name, viewport, mobile) {
+// Desktop is captured full-page (wide aspect, stays reasonable). Mobile is
+// captured at viewport height only: a full-page mobile shot is a ~390x9000
+// sliver that renders as a giant, out-of-proportion strip in the PR comment.
+// A single phone screen is the representative "how does it look on mobile" view.
+async function shoot(browser, name, viewport, mobile, fullPage) {
   const context = await browser.newContext({
     viewport,
     deviceScaleFactor: mobile ? 2 : 1,
@@ -18,7 +22,7 @@ async function shoot(browser, name, viewport, mobile) {
   // Wait for the DOM, then give assets/fonts a moment to paint.
   await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 }).catch(() => {});
   await page.waitForTimeout(3500);
-  await page.screenshot({ path: `${OUT}/${name}.png`, fullPage: true });
+  await page.screenshot({ path: `${OUT}/${name}.png`, fullPage });
   await context.close();
 }
 
@@ -27,8 +31,8 @@ async function shoot(browser, name, viewport, mobile) {
   fs.mkdirSync(OUT, { recursive: true });
 
   const browser = await chromium.launch();
-  await shoot(browser, 'desktop', { width: 1280, height: 900 }, false);
-  await shoot(browser, 'mobile', { width: 390, height: 844 }, true);
+  await shoot(browser, 'desktop', { width: 1280, height: 900 }, false, true);
+  await shoot(browser, 'mobile', { width: 390, height: 844 }, true, false);
   await browser.close();
 
   console.log('Screenshots written to', OUT);

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -79,12 +79,15 @@ jobs:
 
             Automatisch aus diesem PR gebaut (`hugo --minify`), Stand `${{ github.event.pull_request.head.sha }}`.
 
-            **Desktop (1280 px)**
+            <table>
+              <tr>
+                <td align="center"><strong>Desktop (1280 px)</strong></td>
+                <td align="center"><strong>Mobil (390 px)</strong></td>
+              </tr>
+              <tr>
+                <td valign="top"><a href="${{ steps.publish.outputs.desktop_url }}"><img src="${{ steps.publish.outputs.desktop_url }}" alt="Desktop-Vorschau" width="520"></a></td>
+                <td valign="top"><a href="${{ steps.publish.outputs.mobile_url }}"><img src="${{ steps.publish.outputs.mobile_url }}" alt="Mobil-Vorschau" width="220"></a></td>
+              </tr>
+            </table>
 
-            ![Desktop-Vorschau](${{ steps.publish.outputs.desktop_url }})
-
-            **Mobil (390 px)**
-
-            ![Mobil-Vorschau](${{ steps.publish.outputs.mobile_url }})
-
-            <sub>Aktualisiert sich bei jedem neuen Commit. Rohbilder auch als Workflow-Artefakt „frontpage-screenshots".</sub>
+            <sub>Bild anklicken für volle Auflösung. Mobil zeigt den sichtbaren Bereich (kein endloser Vollseiten-Screenshot). Aktualisiert sich bei jedem neuen Commit. Rohbilder auch als Workflow-Artefakt „frontpage-screenshots".</sub>


### PR DESCRIPTION
Der Mobile-Frontpage-Screenshot wurde mit fullPage:true aufgenommen und war dadurch ~390x9400px gross - ein extrem hohes, schmales Bild, das im PR-Kommentar riesig und voellig aus der Proportion wirkte.

- screenshot.js: Mobile jetzt nur noch den sichtbaren Viewport aufnehmen (fullPage:false), Desktop bleibt Vollseite. Ergebnis mobil ~780x1688px, telefontypisches Seitenverhaeltnis.
- pr-screenshots.yml: Desktop und Mobil nebeneinander in einer HTML-Tabelle mit fester Breite (520 / 220 px) statt untereinander gestapelter Vollbreiten-Bilder; Klick auf das Bild oeffnet die volle Aufloesung.